### PR TITLE
Fix fragment size for negative strand

### DIFF
--- a/snapatac2-core/src/feature_count/data_iter.rs
+++ b/snapatac2-core/src/feature_count/data_iter.rs
@@ -40,7 +40,7 @@ fn single_to_fragments(
                 let row_end = row_offsets[i + 1];
                 (row_start..row_end)
                     .flat_map(|j| {
-                        let (chrom, start) = index.get_position(col_indices[j]);
+                        let (chrom, mut start) = index.get_position(col_indices[j]);
                         if exclude_chroms.contains(chrom) {
                             None
                         } else {
@@ -54,6 +54,7 @@ fn single_to_fragments(
                                 strand = Some(Strand::Forward);
                             } else {
                                 end = start + 1;
+                                start = start - (size.abs() as u64);
                                 strand = Some(Strand::Reverse);
                             }
                             Some(Fragment {


### PR DESCRIPTION
Hi! 

Thanks a lot for the awesome repo! I think the Fragment start and end computation for the negative strand for single fragments is not quite correct because it always creates fragments of size 1. I tried to fix it, let me know what you think.

What I did is that I set the new start to be the old start (which is in fact the end for fragments on the minus strand) and subtracted the size of the fragment (I took the abs because it's always negative on the minus strand). One could of course also just do `start = start + size`, but I thought this way it's maybe a bit more intuitive.


Best,
Laura 