### PR TITLE
refactor: use `test` dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,11 @@ recommend = [
 
 [dependency-groups]
 dev = [
+  {include-group = "test"},
+]
+
+# For scverse/integration-testing
+test = [
   "pytest >=8.1.1,<9",
   "hypothesis >=6.72.4,<7",
 ]


### PR DESCRIPTION
I think it would be easier for us to enforce this across scverse repos i.e., everyone needs `test` not `dev` (`dev` could include docs deps, for example).  We should migrate to dependency groups, you are definitely right about that: https://github.com/scverse/cookiecutter-scverse/issues/374 