### PR TITLE
Fix in snap.tl._diff._p_adjust_bh for Numpy > 2.0

### DIFF
--- a/snapatac2/tools/_diff.py
+++ b/snapatac2/tools/_diff.py
@@ -156,7 +156,7 @@ def diff_test(
 
 def _p_adjust_bh(p):
     """Benjamini-Hochberg p-value correction for multiple hypothesis testing."""
-    p = np.asfarray(p)
+    p = np.asarray(p. dtype=np.float64)
     by_descend = p.argsort()[::-1]
     by_orig = by_descend.argsort()
     steps = float(len(p)) / np.arange(len(p), 0, -1)


### PR DESCRIPTION
Numpy removed the `asfarray()` function at some point after 2.0 and says to just set the dtype as an argument and, as such, anything calling `_p_adjust_bh`.